### PR TITLE
Added support IAM group

### DIFF
--- a/iamgroup.tf
+++ b/iamgroup.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_group" "support" {
+  name = "support-team"
+  path = "/support/"
+}


### PR DESCRIPTION
This pull request adds a new IAM group resource named `support`. 

- Resource type: `aws_iam_group`
- Group name: `support-team`
- Path: `/support/`

Please review and approve.
